### PR TITLE
Support for extra authorize query parameters

### DIFF
--- a/lib/Mojolicious/Plugin/OAuth2.pm
+++ b/lib/Mojolicious/Plugin/OAuth2.pm
@@ -89,6 +89,8 @@ sub register {
                 );
                 $fb_url->query->append(scope => $args{scope}) 
                     if exists $args{scope};
+                $fb_url->query($args{authorize_query})
+                    if exists $args{authorize_query};
                 $c->redirect_to($fb_url);
              }
     });

--- a/t/basic.t
+++ b/t/basic.t
@@ -21,12 +21,13 @@ get '/oauth' => sub {
     },
     error_handler => sub { status=>500,$self->render(text=>'oauth failed to get'.shift->req->uri)},
     async => 1,
-    scope => 'fakescope');
+    scope => 'fakescope',
+    authorize_query => { extra => 1 });
 } => 'foo';
 
 get 'fake_auth' => sub {
     my $self=shift;
-    if ($self->param('client_id') && $self->param('redirect_uri') &&$self->param('scope')) {
+    if ($self->param('client_id') && $self->param('redirect_uri') && $self->param('scope') && $self->param('extra')) {
         my $return=Mojo::URL->new($self->param('redirect_uri'));
         $return->query->append(code=>'fake_code');
         $self->redirect_to($return);


### PR DESCRIPTION
Some OAuth2 providers support special query parameters in the
authorize_url. E.g. Facebook supports an auth_type/auth_nounce parameter
to force re-authentication (and HTTPS authentication): http://developers.facebook.com/docs/authentication/reauthentication/
