### PR TITLE
Fix DEPRECATED warning in tests after Mojo v4.50

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -3,8 +3,11 @@ use Test::Mojo;
 use Test::More;
 
 my $t=Test::Mojo->new;
-my $host = $t->ua->app_url->host;
-my $port = $t->ua->app_url->port;
+my $app_url = $Mojolicious::VERSION >= 4.50 
+  ? $t->ua->server->url
+  : $t->ua->app_url;
+my $host = $app_url->host;
+my $port = $app_url->port;
 
 plugin 'OAuth2', test => {
     authorize_url => Mojo::URL->new("http://$host:$port/fake_auth"),

--- a/t/blocking.t
+++ b/t/blocking.t
@@ -3,7 +3,9 @@ use Test::Mojo;
 use Test::More;
 
 my $t=Test::Mojo->new;
-my $port = $t->ua->app_url;
+my $port = $Mojolicious::VERSION >= 4.50 
+  ? $t->ua->server->url
+  : $t->ua->app_url;
 
 plugin 'OAuth2', test => {
     authorize_url => "/fake_auth",


### PR DESCRIPTION
Output without patch:
t/basic.t ..... Mojo::UserAgent::app_url is DEPRECATED in favor of Mojo::UserAgent::Server::url at t/basic.t line 6
Mojo::UserAgent::app_url is DEPRECATED in favor of Mojo::UserAgent::Server::url at t/basic.t line 7
t/basic.t ..... ok
t/blocking.t .. Mojo::UserAgent::app_url is DEPRECATED in favor of Mojo::UserAgent::Server::url at t/blocking.t line 6
t/blocking.t .. ok
t/live.t ...... ok 
