### PR TITLE
Fix Token Extraction

### DIFF
--- a/lib/Mojolicious/Plugin/OAuth2.pm
+++ b/lib/Mojolicious/Plugin/OAuth2.pm
@@ -120,7 +120,7 @@ sub _get_authorize_url {
 
 sub _get_auth_token {
   my ($self,$res)=@_;
-  if($res->headers->content_type =~ /([\w\/+]+)(;\s+charset=(\S+))?/i && $1 eq 'application/json') {
+  if($res->headers->content_type =~ m!^application/json(;\s+charset=\S+)?$!) {
     return $res->json->{access_token};
   }
   my $qp=Mojo::Parameters->new($res->body);


### PR DESCRIPTION
When "charset" is included in Content-Type header, token extraction failed.  This corrects that behaviour.
