### PR TITLE
improved error-handling

### DIFF
--- a/lib/Mojolicious/Plugin/OAuth2.pm
+++ b/lib/Mojolicious/Plugin/OAuth2.pm
@@ -100,6 +100,7 @@ sub register {
                 }
             } else {
                 $c->redirect_to($self->_get_authorize_url($c, $provider_id, %args));
+                return wantarray ? ((undef) x 3) : undef;
             }
     });
 }


### PR DESCRIPTION
Before, if an error occurred during the authorization stage, the user would just keep on visiting the oauth2 provider in an endless loop. With this patch, at least in blocking mode, `get_token` will return ($token, $err, $state) and the user won't enter an endless loop. The programmer can now easily check $err.

If it didn't break backwards compatibility, I would have implemented something similar for the non-blocking mode.