### PR TITLE
Allow text/javascript response.

### DIFF
--- a/lib/Mojolicious/Plugin/OAuth2.pm
+++ b/lib/Mojolicious/Plugin/OAuth2.pm
@@ -122,7 +122,7 @@ sub _get_authorize_url {
 
 sub _get_auth_token {
   my ($self,$res)=@_;
-  if($res->headers->content_type =~ m!^application/json(;\s+charset=\S+)?$!) {
+  if($res->headers->content_type =~ m!^(application/json|text/javascript)(;\s+charset=\S+)?$!) {
     return $res->json->{access_token};
   }
   my $qp=Mojo::Parameters->new($res->body);


### PR DESCRIPTION
Simply because the Dropbox API returns text/javascript instead of application/json:

headers       => {
                   "cache-control"           => [["no-cache"]],
                   "connection"              => [["keep-alive"]],
                   "content-length"          => [[127]],
                   "content-type"            => [["text/javascript"]],
                   "date"                    => [["Mon, 05 May 2014 13:07:31 GMT"]],
                   "pragma"                  => [["no-cache"]],
                   "server"                  => [["nginx"]],
                   "x-dropbox-http-protocol" => [["None"]],
                   "x-dropbox-request-id"    => [["2063b64ae56844ebaee02289f267b393"]],
                   "x-frame-options"         => [["SAMEORIGIN"]],
                   "x-requestid"             => [["0b0c84030cc157d659d4244e2d668fd4"]],
                   "x-server-response-time"  => [[119]],
                 },
