### PR TITLE
Content type matching problem with LinkedIn

### DIFF
--- a/lib/Mojolicious/Plugin/OAuth2.pm
+++ b/lib/Mojolicious/Plugin/OAuth2.pm
@@ -136,7 +136,7 @@ sub _get_authorize_url {
 
 sub _get_auth_token {
   my ($self, $res) = @_;
-  if ($res->headers->content_type =~ m!^(application/json|text/javascript)(;\s+charset=\S+)?$!) {
+  if ($res->headers->content_type =~ m!^(application/json|text/javascript)(;\s*charset=\S+)?$!) {
     return $res->json->{access_token};
   }
   my $qp = Mojo::Parameters->new($res->body);


### PR DESCRIPTION
I've recently encountered a problem using the LinkedIn configuration for this plugin. The rule for matching the content type should look like this:

m!^(application/json|text/javascript)(;\s*charset=\S+)?$!

because in the LinkedIn case there is no space between the content type and the charset definition. Also maybe you should include an else statement for this rule in case is not matched.
