### PR TITLE
Add new helpers oauth2.auth_url, .providers and .get_token

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -37,6 +37,6 @@ WriteMakefile(
     )
   ),
 
-  PREREQ_PM => {'Mojolicious' => '1.64', 'IO::Socket::SSL' => 0,},
+  PREREQ_PM => {'Mojolicious' => '6.00', 'IO::Socket::SSL' => 0},
   test      => {TESTS         => 't/*.t t/*/*.t t/*/*/*.t t/*/*/*/*.t'}
 );

--- a/t/oauth2-auth_url.t
+++ b/t/oauth2-auth_url.t
@@ -1,0 +1,39 @@
+use Mojo::Base -strict;
+use Test::Mojo;
+use Test::More;
+
+my $authorize_args = {};
+
+use Mojolicious::Lite;
+plugin 'OAuth2' => {facebook => {key => 'KEY'}};
+get '/test123', sub { $_[0]->render(text => $_[0]->oauth2->auth_url('facebook', $authorize_args)); };
+
+my $t = Test::Mojo->new;
+
+eval { $t->app->get_authorize_url };
+like $@, qr{Unknown OAuth2 provider}, 'provider_id is required';
+
+$t->get_ok('/test123')->status_is(200);
+my $url = Mojo::URL->new($t->tx->res->body);
+like $url, qr{^https://graph\.facebook\.com/oauth/authorize}, 'base url';
+is $url->query->param('client_id'),      'KEY',         'client_id';
+like $url->query->param('redirect_uri'), qr{/test123$}, 'redirect_uri';
+
+$authorize_args = {
+  scope           => 'email,age',
+  redirect_uri    => 'https://example.com',
+  host            => 'oauth2.example.com',
+  state           => '42',
+  authorize_query => {foo => 123},
+};
+
+$t->get_ok('/test123')->status_is(200);
+$url = Mojo::URL->new($t->tx->res->body);
+like $url, qr{^https://oauth2\.example\.com/oauth/authorize}, 'custom.host';
+is $url->query->param('foo'),          '123',                 'foo';
+is $url->query->param('client_id'),    'KEY',                 'client_id';
+is $url->query->param('redirect_uri'), 'https://example.com', 'custom.redirect_uri';
+is $url->query->param('scope'),        'email,age',           'scope';
+is $url->query->param('state'),        '42',                  'state';
+
+done_testing;

--- a/t/oauth2-get_token.t
+++ b/t/oauth2-get_token.t
@@ -1,0 +1,40 @@
+use t::Helper;
+
+my $app = t::Helper->make_app;
+my $t   = Test::Mojo->new($app);
+
+Mojo::Util::monkey_patch('Mojolicious::Plugin::OAuth2', _ua => sub { $t->ua });
+
+$app->routes->get(
+  '/test123' => sub {
+    my $c = shift;
+
+    $c->delay(
+      sub {
+        my $delay = shift;
+        $c->oauth2->get_token(test => $delay->begin);
+      },
+      sub {
+        my ($delay, $err, $token) = @_;
+        return $c->render(text => $err, status => 500) if $err;
+        return $c->render(text => "Token $token");
+      },
+    );
+  }
+);
+
+$t->get_ok('/test123')->status_is(302);    # ->content_like(qr/bar/);
+my $location     = Mojo::URL->new($t->tx->res->headers->location);
+my $callback_url = Mojo::URL->new($location->query->param('redirect_uri'));
+is($location->query->param('client_id'), 'fake_key', 'got client_id');
+
+$t->get_ok($location)->status_is(302);
+my $res = Mojo::URL->new($t->tx->res->headers->location);
+is($res->path,                 $callback_url->path, 'Returns to the right place');
+is($res->query->param('code'), 'fake_code',         'Includes fake code');
+
+$t->get_ok($res)->status_is(200)->content_is('Token fake_token');
+
+$t->get_ok('/test123?error=access_denied')->status_is(500)->content_is('access_denied');
+
+done_testing;


### PR DESCRIPTION
This branch contains new helpers:

* oauth2.auth_url is the same as the old get_authorize_url()
* oauth2.providers is new, and will return whatever the providers attribute holds
* oauth2.get_token is almost the same as get_token, except:
  * It does not support blocking mode
  * It pass on ```($c, $err, $token)``` to the callback, instead of ```($c, $token, $tx)```