### PR TITLE
Need to pass the whole result object back to the callback

### DIFF
--- a/t/Helper.pm
+++ b/t/Helper.pm
@@ -9,7 +9,8 @@ sub make_app {
 
   $app->plugin(
     OAuth2 => {
-      test => {
+      fix_get_token => 1,
+      test          => {
         authorize_url => '/oauth/authorize',
         token_url     => '/oauth/token',
         key           => 'fake_key',

--- a/t/get_authorize_url.t
+++ b/t/get_authorize_url.t
@@ -5,7 +5,7 @@ use Test::More;
 my $authorize_args = {};
 
 use Mojolicious::Lite;
-plugin 'OAuth2' => {facebook => {key => 'KEY'}};
+plugin 'OAuth2' => {fix_get_token => 1, facebook => {key => 'KEY'}};
 get '/test123', sub { $_[0]->render(text => $_[0]->get_authorize_url('facebook', $authorize_args)); };
 
 my $t = Test::Mojo->new;

--- a/t/mocked.t
+++ b/t/mocked.t
@@ -5,7 +5,7 @@ use Test::More;
 
 {
   use Mojolicious::Lite;
-  plugin OAuth2 => {mocked => {key => '42'}};
+  plugin OAuth2 => {fix_get_token => 1, mocked => {key => '42'}};
   get '/test123' => sub {
     my $c = shift;
 
@@ -15,9 +15,9 @@ use Test::More;
         $c->oauth2->get_token(mocked => $delay->begin);
       },
       sub {
-        my ($delay, $err, $token) = @_;
+        my ($delay, $err, $data) = @_;
         return $c->render(text => $err, status => 500) if $err;
-        return $c->render(text => "Token $token");
+        return $c->render(text => "Token $data->{access_token}");
       },
     );
   };

--- a/t/oauth2-auth_url.t
+++ b/t/oauth2-auth_url.t
@@ -5,12 +5,12 @@ use Test::More;
 my $authorize_args = {};
 
 use Mojolicious::Lite;
-plugin 'OAuth2' => {facebook => {key => 'KEY'}};
+plugin 'OAuth2' => {fix_get_token => 1, facebook => {key => 'KEY'}};
 get '/test123', sub { $_[0]->render(text => $_[0]->oauth2->auth_url('facebook', $authorize_args)); };
 
 my $t = Test::Mojo->new;
 
-eval { $t->app->get_authorize_url };
+eval { $t->app->oauth2->auth_url };
 like $@, qr{Unknown OAuth2 provider}, 'provider_id is required';
 
 $t->get_ok('/test123')->status_is(200);

--- a/t/oauth2-get_token.t
+++ b/t/oauth2-get_token.t
@@ -15,9 +15,9 @@ $app->routes->get(
         $c->oauth2->get_token(test => $delay->begin);
       },
       sub {
-        my ($delay, $err, $token) = @_;
+        my ($delay, $err, $data) = @_;
         return $c->render(text => $err, status => 500) if $err;
-        return $c->render(text => "Token $token");
+        return $c->render(text => "Token $data->{access_token}");
       },
     );
   }


### PR DESCRIPTION
We mess up when we simplified the API in version 1.5: The callback given to get_token() should receive a data structure and not just a string. Reason for this is that the data sent back from the provider also contains other useful information.

This PR is back compat, but will allow people to move forward with the api, by setting ```fix_get_token```.