### PR TITLE
liftetime isn't a valid paramater

### DIFF
--- a/lib/Mojolicious/Plugin/OAuth2.pm
+++ b/lib/Mojolicious/Plugin/OAuth2.pm
@@ -288,7 +288,7 @@ sub _mock_interface {
     $provider->{token_url} => sub {
       my $c = shift;
       if ($c->param('client_secret') and $c->param('redirect_uri') and $c->param('code')) {
-        my $qp = Mojo::Parameters->new(access_token => $provider->{return_token}, lifetime => 3600);
+        my $qp = Mojo::Parameters->new(access_token => $provider->{return_token}, expires_in => 3600);
         $c->render(text => $qp->to_string);
       }
       else {


### PR DESCRIPTION
I may be misunderstanding something about the OAuth2 protocol, but I can't find lifetime defined anywhere.  If I understand the mocked option it is faking a call to an external OAuth2 Provider and therefore should respond in the same valid manner.