### PR TITLE
add 'debian_salsa' as an OAuth2 id provider

### DIFF
--- a/lib/Mojolicious/Plugin/OAuth2.pm
+++ b/lib/Mojolicious/Plugin/OAuth2.pm
@@ -14,6 +14,10 @@ has providers => sub {
       authorize_url => "https://api.dailymotion.com/oauth/authorize",
       token_url     => "https://api.dailymotion.com/oauth/token"
     },
+    debian_salsa => {
+      authorize_url => 'https://salsa.debian.org/oauth/authorize?response_type=code',
+      token_url     => 'https://salsa.debian.org/oauth/token',
+    },
     eventbrite => {
       authorize_url => 'https://www.eventbrite.com/oauth/authorize',
       token_url     => 'https://www.eventbrite.com/oauth/token',
@@ -283,6 +287,10 @@ values for C<authorize_url> and C<token_url> for the following providers:
 =item * dailymotion
 
 Authentication for Dailymotion video site.
+
+=item * debian_salsa
+
+Authentication for L<https://salsa.debian.org/>.
 
 =item * eventbrite
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Mojolicious-Plugin-OAuth2.
We thought you might be interested in it too.

    From: Philip Hands <phil@hands.com>
    Date: Thu, 4 Mar 2021 06:36:09 +0100
    Subject: add 'debian_salsa' as an OAuth2 id provider
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libmojolicious-plugin-oauth2-perl/raw/master/debian/patches/0001-add-salsa-as-an-OAuth2-id-provider.patch


Not sure if it makes sense to include this relatively Debian specific
provider upstream; but salsa can also be used by non-Debian Free Software
projects, and probably it doesn't hurt â¦


Thanks for considering,
  gregor herrmann,
  Debian Perl Group
