### PR TITLE
Better error handling for OIDC warmup errors, resolves #77

### DIFF
--- a/lib/Mojolicious/Plugin/OAuth2/Mock.pm
+++ b/lib/Mojolicious/Plugin/OAuth2/Mock.pm
@@ -149,8 +149,14 @@ sub _action_token_endpoint {
 sub _action_well_known {
   my ($self, $c) = @_;
   my $provider = $self->provider;
-  my $req_url  = $c->req->url->to_abs;
-  my $to_abs   = sub { $req_url->path(Mojo::URL->new(shift)->path)->to_abs };
+
+  if ($provider->{key} eq 'invalid') {
+    $c->render(text => 'FAIL INVALID', status => 400);
+    return;
+  }
+
+  my $req_url = $c->req->url->to_abs;
+  my $to_abs  = sub { $req_url->path(Mojo::URL->new(shift)->path)->to_abs };
 
   $c->render(
     template               => 'oauth2/mock/configuration',

--- a/t/oidc-error.t
+++ b/t/oidc-error.t
@@ -1,0 +1,26 @@
+use Mojo::Base -strict;
+use Test::More;
+use Test::Mojo;
+use MIME::Base64 qw(encode_base64url);
+use Mojo::JSON qw(decode_json encode_json);
+use Mojo::URL;
+use Mojolicious::Plugin::OAuth2;
+
+plan skip_all => "Mojo::JWT, Crypt::OpenSSL::RSA and Crypt::OpenSSL::Bignum required for openid tests"
+  unless Mojolicious::Plugin::OAuth2::MOJO_JWT;
+
+use Mojolicious::Lite;
+
+my $error = '';
+
+plugin OAuth2 => {
+  mocked => {
+    key                   => 'invalid',
+    well_known_url        => '/mocked/oauth2/.well-known/configuration',
+    warmup_error_callback => sub { $error = $_[1] },
+  }
+};
+
+like($error, qr/^Bad Request/, 'invalid key triggers callback');
+
+done_testing;


### PR DESCRIPTION
Here my first shot at this.
I think a callback provides a bit of flexibility for the user. 
The name might be a bit long though.